### PR TITLE
clarify mk2/mk3 speedhack default

### DIFF
--- a/src/libretro/libretro.c
+++ b/src/libretro/libretro.c
@@ -56,11 +56,7 @@ float vector_intensity = 1.5f;     /* float: vector beam intensity */
 
 extern int crosshair_enable;
 
-#if defined(__CELLOS_LV2__) || defined(GEKKO) || defined(_XBOX)
 unsigned activate_dcs_speedhack = 1;
-#else
-unsigned activate_dcs_speedhack = 0;
-#endif
 
 #ifdef _3DS
 int stricmp(const char *string1, const char *string2)
@@ -89,13 +85,7 @@ void retro_set_environment(retro_environment_t cb)
 {
    static const struct retro_variable vars[] = {
       { "mame2003-plus-frameskip", "Frameskip; 0|1|2|3|4|5" },
-      { "mame2003-plus-dcs-speedhack",
-#if defined(__CELLOS_LV2__) || defined(GEKKO) || defined(_XBOX)
-         "MK2/MK3 DCS Speedhack; disabled|enabled"
-#else
-         "MK2/MK3 DCS Speedhack; enabled|disabled"
-#endif
-      },
+      { "mame2003-plus-dcs-speedhack","MK2/MK3 DCS Speedhack; enabled|disabled"},
       { "mame2003-plus-skip_disclaimer", "Skip Disclaimer; enabled|disabled" },
       { "mame2003-plus-skip_warnings", "Skip Warnings; disabled|enabled" },
       { "mame2003-plus-sample_rate", "Sample Rate (KHz); 48000|8000|11025|22050|44100" },


### PR DESCRIPTION
These defaults seem to be reversed compared to the intention.

The intention can be seen here https://github.com/arcadez/mame2003-plus-libretro/blob/master/src/libretro/libretro.c#L59-L63

The intention is that low-powered systems have the speedhacks turned on by default. However the default that is sent to libretro is backwards, so that the low-powered systems **do not** get the speedhack by default but everyone else does.

My question @arcadez is -- should the default be to turn this on for everyone? Is there any reason this is the way it is now?